### PR TITLE
Fix maven artifact id in models

### DIFF
--- a/models-v3/README.adoc
+++ b/models-v3/README.adoc
@@ -1,5 +1,5 @@
 :module-name: Models v3
-:maven-artifact-id: model-v3
+:maven-artifact-id: models-v3
 
 ifndef::maven-group-id[]
 :maven-group-id: com.unblu.openapi


### PR DESCRIPTION
It should be `models-v3` and not `model-v3`